### PR TITLE
Fixed stray curly brace and double pageEntryCount increment

### DIFF
--- a/scripts/courses/createCourseEntries.js
+++ b/scripts/courses/createCourseEntries.js
@@ -235,12 +235,11 @@ const createEntries = async (courses) => {
           };
         }
 
-        pageEntryCount++;
         // Log the update to the text file
         const logData =
           `${pageEntryCount}. pageEntry  ${pageEntry.fields.slug["en-GB"]} - ${pageEntry.sys.id}\n` +
           `        metaInfoEntry ${metaInfoEntry.fields.systemName["en-GB"]} - ${metaInfoEntry.sys.id}\n` +
-          `        courseData ${dataEntry.fields.templateIdString["en-GB"]} - ${dataEntry.sys.id}}`;
+          `        courseData ${dataEntry.fields.templateIdString["en-GB"]} - ${dataEntry.sys.id}`;
         writeToLogFile(logData);
 
         await pageEntry.update();


### PR DESCRIPTION
This PR resolves two small bugs with the course import script logging. 

1. A stray curly brace at the end of the log message
2. `pageEntryCount++` was being called twice in error