### PR TITLE
increase the limit of content types fetched by getContentTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function execMe(cmd, name) {
 }
 
 client
-  .getContentTypes()
+  .getContentTypes({ limit: 300 })
   .then(async contentTypes => {
     const generateMigrations = async () => {
       console.log('=====Generating content model migrations=====');


### PR DESCRIPTION
By default the `getContentTypes` method has a limit of 100 content types it will fetch.

This PR increases that limit to ensure all our content types are processed by when the migration generator runs.